### PR TITLE
Upgrade dotnet target

### DIFF
--- a/src/Mentat.Domain/Mentat.Domain.csproj
+++ b/src/Mentat.Domain/Mentat.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -9,9 +9,11 @@
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Interfaces\" />
+    <None Remove="Models\" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Interfaces\" />
+    <Folder Include="Models\" />
   </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>

--- a/src/Mentat.UI/Mentat.UI.csproj
+++ b/src/Mentat.UI/Mentat.UI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mentat.UI/Startup.cs
+++ b/src/Mentat.UI/Startup.cs
@@ -9,6 +9,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
+using Mentat.Domain.Interfaces;
+// using Mentat.Domain.Models;
+
 namespace Mentat.UI
 {
     public class Startup
@@ -24,6 +27,10 @@ namespace Mentat.UI
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllersWithViews();
+
+            // Configure Dependency Injection classes here
+            // services.AddScoped<IBashTestConfig, BashTestConfig>();
+            // services.AddScoped<IBashTestDriver, BashTestDriver>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/tests/Mentat.Domain.Tests/Mentat.Domain.Tests.csproj
+++ b/tests/Mentat.Domain.Tests/Mentat.Domain.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Mentat.Domain.Tests/Mentat.Domain.Tests.csproj
+++ b/tests/Mentat.Domain.Tests/Mentat.Domain.Tests.csproj
@@ -17,10 +17,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.DependencyInjection" Version="8.5.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Mentat.Domain\Mentat.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Xunit.DependencyInjection" />
   </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>

--- a/tests/Mentat.Domain.Tests/Startup.cs
+++ b/tests/Mentat.Domain.Tests/Startup.cs
@@ -1,0 +1,25 @@
+﻿// Startup.cs
+// dyohn
+// 6/25/2022
+//
+// See: https://github.com/pengweiqhca/Xunit.DependencyInjection
+// for more information about usage.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+using Mentat.Domain.Interfaces;
+// using Mentat.Domain.Models;
+
+namespace Mentat.Domain.Tests
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            //services.AddTransient<IBashTestConfig, BashTestConfig>();
+            //services.AddTransient<IBashTestDriver, BashTestDriver>();
+        }
+    }
+}
+


### PR DESCRIPTION
### What It Does
This PR has three components. 

First, it upgrades our target .NET from 5 to 6. This is necessary because .NET 5 is no longer in support and will not receive future security upgrades. We need to move to the next LTS version.

Second, I have provided, in Mentat.UI, a very basic example of how we will register services for dependency injection. I have chosen Scoped as the example instead of Transient, purely for minor performance reasons. Please note that the choices are not limited to Scoped or Transient, and the choice should be made based on the context and intended usage. See https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-guidelines for more information.

Third, I have added support for dependency injection to the xUnit test project, Mentat.Domain.Tests. This is likely not complete, as I have not used this feature before, at least in this way or for .NET Core. However, supporting packages have been added (most notably xUnit.DependencyInjection), and I have added the initial Startup definition with DI examples. The exact usage pattern is a little unclear at this time, but we can work out the details over time. See https://github.com/pengweiqhca/Xunit.DependencyInjection for more information.

### What It Does Not
Please note that no effort has been made here to migrate to the new hosting patterns for .NET 6, though we may wish to do so at a later date. See https://docs.microsoft.com/en-us/aspnet/core/migration/50-to-60?view=aspnetcore-6.0 for more information.

### Caveats
* Dependency Injection is not available in class libraries (Mentat.Domain). We must still write our interfaces and models as we would were it available, because when/where the domain library is imported and used, DI will be available to resolve the references.
* If you are on Mac, you will likely need to upgrade to the Visual Studio for Mac 2022, as .NET 6 is not fully supported on prior versions. 

### How To Test
Pull this branch and build the solution. It should run just as it previously has.