### PR TITLE
Fixing a bug with DifficultyLevel (difficulty_level)

### DIFF
--- a/src/Mentat.Repository/Models/Card.cs
+++ b/src/Mentat.Repository/Models/Card.cs
@@ -21,7 +21,7 @@ namespace Mentat.Repository.Models
         [BsonElement("isCustom")]
         public bool IsCustom { get; set; }
 
-        [BsonElement("difficulty_level")]
+        [BsonElement("difficultyLevel")]
         public string DifficultyLevel { get; set; }
 
         [BsonElement("notes")]

--- a/src/Mentat.UI/Controllers/CardController.cs
+++ b/src/Mentat.UI/Controllers/CardController.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Mentat.Repository.Services;
@@ -52,13 +51,12 @@ namespace Mentat.UI.Controllers
                 var id = Guid.NewGuid().ToString();
                 cardService.CreateCard(new Repository.Models.Card
                 {
-                  Id = id,
-                  Notes = collection["notes"],
-                  Subject = collection["subject"],
-                  Question = collection["question"],
-                  Answer = collection["answer"],
-                  DifficultyLevel = collection["difficulty_level"]
-
+                    Id = id,
+                    Notes = collection["notes"],
+                    Subject = collection["subject"],
+                    Question = collection["question"],
+                    Answer = collection["answer"],
+                    DifficultyLevel = collection["difficultyLevel"]
                 });
                 
                 return RedirectToAction(nameof(Index));
@@ -98,7 +96,7 @@ namespace Mentat.UI.Controllers
                 existingCard.Subject = collection["subject"];
                 existingCard.Question= collection["question"];
                 existingCard.Answer = collection["answer"];
-                existingCard.DifficultyLevel = collection["difficulty_level"];
+                existingCard.DifficultyLevel = collection["difficultyLevel"];
                 cardService.UpdateCard(id, existingCard);
 
                 return RedirectToAction(nameof(Index));


### PR DESCRIPTION
Fixing a bug with DifficultyLevel (difficulty_level), it was no longer saving in add or edit. The CardController references to the collection attribute had not been updated with the new name change.
Also, updating DB field difficulty_level to difficultyLevel.
Note: All that is really needed to fix this bug is the changes in CardController, but I think the DB field name needs to be updated as well, since the DB is still so small and the snake_case is ultimately not what (I think) we want, for consistency (isCustom) and c# standards. After this change is merged, I will update all of the documents in Mongo to have the new name for the field and then instruct the class to pull latest from `development`.