### PR TITLE
[For Mimi] Helping with difficulty level color display

### DIFF
--- a/src/Mentat.Domain/Models/StudentVM.cs
+++ b/src/Mentat.Domain/Models/StudentVM.cs
@@ -15,6 +15,14 @@ namespace Mentat.Domain.Models
         public string CardID { get; set; }
         public string Subject { get; set; }
         public string DifficultyLevel { get; set; }
+        public string DifficultyLevelColor => DifficultyLevel switch
+        {
+            nameof(Constants.DifficultyLevel.Easy) => "green",
+            nameof(Constants.DifficultyLevel.Medium) => "yellow",
+            nameof(Constants.DifficultyLevel.Hard) => "orange",
+            nameof(Constants.DifficultyLevel.Expert) => "red",
+            _ => "purple",
+        };
         public string CardQuestion { get; set; }
         public string HiddenCardAnswer { get; set; }
         public string CardAnswerOverlay => "";

--- a/src/Mentat.UI/Views/Student/Index.cshtml
+++ b/src/Mentat.UI/Views/Student/Index.cshtml
@@ -28,7 +28,12 @@
 {
     var display = i == 1 ? "inline" : "none";
     <div id="flashcard_@i" style="display:@display">
-        @Html.Partial("_Flashcard", Model.AvailableCards[i - 1], new ViewDataDictionary(ViewData) { { "index", i } })
+        <div class="col-sm-12">
+            <div style="background-color: @Model.AvailableCards[i - 1].DifficultyLevelColor">&nbsp;</div>
+            <div>
+                @Html.Partial("_Flashcard", Model.AvailableCards[i - 1], new ViewDataDictionary(ViewData) { { "index", i } })
+            </div>
+        </div>
     </div>
 }
 


### PR DESCRIPTION
As I mentioned to her, this does not yet look the way we want it. I haven't figured out how to display the color div beside the div holding the rest of the card's info, but I wanted to get her headed in the right direction.
The VM is bringing in the difficulty level color with the rest of the attributes now and the html is assigning that color to the background of a div.

@MimiC-H, you just need to work on getting the two divs to display beside each other instead of on top of each other. Google something like "display divs beside each other mvc razor c#". Hopefully you can find something that works. Happy coding!

**Note**: This PR is set to merge only into Mimi's branch, once she approves it, I will merge it into her branch.