### PR TITLE
M-03.05 Public private flashcards

### DIFF
--- a/src/Mentat.Repository/Models/Card.cs
+++ b/src/Mentat.Repository/Models/Card.cs
@@ -9,6 +9,9 @@ namespace Mentat.Repository.Models
         [BsonElement("_id")]
         public string Id { get; set; }
 
+        [BsonElement("_owner")]
+        public string Owner { get; set; }
+
         [BsonElement("subject")]
         public string Subject { get; set; }
 

--- a/src/Mentat.Repository/Models/Card.cs
+++ b/src/Mentat.Repository/Models/Card.cs
@@ -24,6 +24,9 @@ namespace Mentat.Repository.Models
         [BsonElement("difficultyLevel")]
         public string DifficultyLevel { get; set; }
 
+        [BsonElement("owner")]
+        public string Owner { get; set; }
+
         [BsonElement("notes")]
         public string Notes { get; set; }
 

--- a/src/Mentat.Repository/Models/Card.cs
+++ b/src/Mentat.Repository/Models/Card.cs
@@ -31,9 +31,6 @@ namespace Mentat.Repository.Models
         [BsonElement("difficultyLevel")]
         public string DifficultyLevel { get; set; }
 
-        [BsonElement("owner")]
-        public string Owner { get; set; }
-
         [BsonElement("notes")]
         public string Notes { get; set; }
 

--- a/src/Mentat.Repository/Models/Card.cs
+++ b/src/Mentat.Repository/Models/Card.cs
@@ -10,7 +10,7 @@ namespace Mentat.Repository.Models
         [BsonElement("_id")]
         public string Id { get; set; }
 
-        [BsonElement("_owner")]
+        [BsonElement("owner")]
         public string Owner { get; set; }
 
         [BsonElement("subject")]

--- a/src/Mentat.Repository/Models/Card.cs
+++ b/src/Mentat.Repository/Models/Card.cs
@@ -25,6 +25,9 @@ namespace Mentat.Repository.Models
         [BsonElement("isCustom")]
         public bool IsCustom { get; set; }
 
+        [BsonElement("isPrivate")]
+        public bool IsPrivate { get; set; }
+
         [BsonElement("difficultyLevel")]
         public string DifficultyLevel { get; set; }
 

--- a/src/Mentat.Repository/Models/Card.cs
+++ b/src/Mentat.Repository/Models/Card.cs
@@ -3,6 +3,7 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace Mentat.Repository.Models
 {
+    [BsonIgnoreExtraElements]
     public class Card
     {
         [BsonId]

--- a/src/Mentat.Repository/Services/CardService.cs
+++ b/src/Mentat.Repository/Services/CardService.cs
@@ -23,18 +23,18 @@ namespace Mentat.Repository.Services
 
         public List<Card> GetFilteredCardsList(List<string> difficultyLevels)
         {
-            List<Card> cards = new List<Card>();
+            // Removed the creation of a new list directly
             try
             {
-                // Get all cards if list of difficulty levels empty.
+                // Get all cards if list of difficulty levels is empty.
                 if (difficultyLevels == null)
                 {
-                    cards = _cards.Find(card => true).ToList();
+                    return _cards.Find(card => true).ToList();
                 }
                 // Else get the cards of specified difficulty.
                 else
                 {
-                    cards = _cards.Find(c => difficultyLevels.Contains(c.DifficultyLevel)).ToList();
+                    return _cards.Find(c => difficultyLevels.Contains(c.DifficultyLevel)).ToList();
                 }
             }
             // Add a card marked with error info in case of exception.
@@ -42,9 +42,9 @@ namespace Mentat.Repository.Services
             {
                 Card c = new Card();
                 c.Answer = $"There was a problem retrieving cards.";
-                cards.Add(c);
+                // Instead, result of ToList() is called and the returned list is a new instance
+                return new List<Card> { c };
             }
-            return cards;
         }
 
         public List<string> GetAllTags()

--- a/src/Mentat.Repository/Services/CardService.cs
+++ b/src/Mentat.Repository/Services/CardService.cs
@@ -121,5 +121,16 @@ namespace Mentat.Repository.Services
             }
 
         }
+
+        public void CowCard(string id, string newOwner)
+        {
+            string newId = Guid.NewGuid().ToString();
+            Card card = GetCard(id);
+            card.Id = newId;
+            card.Owner = newOwner;
+            SaveCard(newId, card);
+            return;
+        }
+
     }
 }

--- a/src/Mentat.Repository/Services/CardService.cs
+++ b/src/Mentat.Repository/Services/CardService.cs
@@ -81,6 +81,7 @@ namespace Mentat.Repository.Services
             {
                 card.Subject = "There was a problem retrieving the card";
             }
+
             return card;
         }
 
@@ -109,6 +110,15 @@ namespace Mentat.Repository.Services
             else
             {
                 card.Id = Guid.NewGuid().ToString();
+                if (card.IsPrivate == true)
+                {
+                    card.IsCustom = true;
+                }
+                if (card.IsPrivate == false)
+                {
+                    card.IsCustom = false;
+                    card.Owner = "mentat";
+                }
             }
 
             try

--- a/src/Mentat.Repository/Services/ICardService.cs
+++ b/src/Mentat.Repository/Services/ICardService.cs
@@ -15,5 +15,7 @@ namespace Mentat.Repository.Services
         void RemoveCard(string id);
 
         void SaveCard(string id, Card card);
+
+        public void CowCard(string id, string newOwner);
     }
 }

--- a/src/Mentat.UI/Controllers/CardController.cs
+++ b/src/Mentat.UI/Controllers/CardController.cs
@@ -55,6 +55,37 @@ namespace Mentat.UI.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult SaveCard(string id, [FromForm] Card card, [FromForm] string tagList)
         {
+            //private new owner
+            //private existing owner
+            //public existing owner
+            //public new owner
+
+            Card oldCard;
+            // check if this is a new card that's being created.
+            if (id == null)
+            {
+                oldCard = null;
+            }
+            // load old card.
+            else
+            {
+                oldCard = _cardService.GetCard(id);
+                oldCard.Owner ??= card.Owner; // set old Owner to new owner if old owner is null
+            }
+            if ((oldCard != null) && (oldCard.Owner != card.Owner))
+            {
+                // check if old card owner is not who modified card and private.
+                if (oldCard.IsPrivate)
+                {
+                    return NotFound($"{card.Owner} is not the owner of this card and cannot edit it while it is set to private.");
+                }
+                else // check if public and new owner setting private
+                {
+                    id = null;
+                    card.Id = null;
+                }
+            }
+            // should be old owner updating card or new owner adding card.
             try
             {
                 // If tags were provided, they are submitted as a comma-separated string

--- a/src/Mentat.UI/Controllers/CardController.cs
+++ b/src/Mentat.UI/Controllers/CardController.cs
@@ -55,37 +55,29 @@ namespace Mentat.UI.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult SaveCard(string id, [FromForm] Card card, [FromForm] string tagList)
         {
-            //private new owner
-            //private existing owner
-            //public existing owner
-            //public new owner
-
+            // Checks if card provided is new or exists. If the card exists, checks owner changes.
             Card oldCard;
-            // check if this is a new card that's being created.
             if (id == null)
             {
                 oldCard = null;
             }
-            // load old card.
             else
             {
                 oldCard = _cardService.GetCard(id);
-                oldCard.Owner ??= card.Owner; // set old Owner to new owner if old owner is null
+                oldCard.Owner ??= card.Owner;
             }
             if ((oldCard != null) && (oldCard.Owner != card.Owner))
             {
-                // check if old card owner is not who modified card and private.
                 if (oldCard.IsPrivate)
                 {
                     return NotFound($"{card.Owner} is not the owner of this card and cannot edit it while it is set to private.");
                 }
-                else // check if public and new owner setting private
+                else
                 {
                     id = null;
                     card.Id = null;
                 }
             }
-            // should be old owner updating card or new owner adding card.
             try
             {
                 // If tags were provided, they are submitted as a comma-separated string

--- a/src/Mentat.UI/Controllers/CardController.cs
+++ b/src/Mentat.UI/Controllers/CardController.cs
@@ -74,19 +74,6 @@ namespace Mentat.UI.Controllers
             }
         }
 
-        // DEPRICATED - Please use the Delete function below with a user parameter
-        // GET: CardController/Delete/5
-        public ActionResult Delete(string id)
-        {
-            var card = _cardService.GetCard(id);
-            if (card == null)
-            {
-                return NotFound($"Card with ID = {id} not found");
-            }
-
-            return View(new CardViewModel(card));
-        }
-
         // GET: CardController/Delete/5
         public ActionResult Delete(string id, string user)
         {

--- a/src/Mentat.UI/Controllers/CardController.cs
+++ b/src/Mentat.UI/Controllers/CardController.cs
@@ -113,6 +113,10 @@ namespace Mentat.UI.Controllers
             {
                 return NotFound($"{user} is not the owner of this card and cannot delete it.");
             }
+            if (!card.IsPrivate)
+            {
+                return NotFound($"The card is not set to private and cannot be deleted.");
+            }
             if (card == null)
             {
                 return NotFound($"Card with ID = {id} not found");

--- a/src/Mentat.UI/Controllers/CardController.cs
+++ b/src/Mentat.UI/Controllers/CardController.cs
@@ -74,10 +74,27 @@ namespace Mentat.UI.Controllers
             }
         }
 
+        // DEPRICATED - Please use the Delete function below with a user parameter
         // GET: CardController/Delete/5
         public ActionResult Delete(string id)
         {
             var card = _cardService.GetCard(id);
+            if (card == null)
+            {
+                return NotFound($"Card with ID = {id} not found");
+            }
+
+            return View(new CardViewModel(card));
+        }
+
+        // GET: CardController/Delete/5
+        public ActionResult Delete(string id, string user)
+        {
+            var card = _cardService.GetCard(id);
+            if (card.Owner != user)
+            {
+                return NotFound($"{user} is not the owner of this card and cannot delete it.");
+            }
             if (card == null)
             {
                 return NotFound($"Card with ID = {id} not found");

--- a/src/Mentat.UI/ViewModels/CardViewModel.cs
+++ b/src/Mentat.UI/ViewModels/CardViewModel.cs
@@ -7,6 +7,8 @@ namespace Mentat.UI.ViewModels
     {
         public string Id { get; set; }
 
+        public string Owner { get; set; }
+
         public string Subject { get; set; }
 
         public string Question { get; set; }
@@ -26,6 +28,7 @@ namespace Mentat.UI.ViewModels
         public CardViewModel(Card card)
         {
             Id = card.Id;
+            Owner = card.Owner;
             Subject = card.Subject;
             Question = card.Question;
             Answer = card.Answer;

--- a/src/Mentat.UI/ViewModels/CardViewModel.cs
+++ b/src/Mentat.UI/ViewModels/CardViewModel.cs
@@ -17,6 +17,8 @@ namespace Mentat.UI.ViewModels
 
         public bool IsCustom { get; set; }
 
+        public bool IsPrivate { get; set; }
+
         public string DifficultyLevel { get; set; }
 
         public string Notes { get; set; }
@@ -32,7 +34,8 @@ namespace Mentat.UI.ViewModels
             Subject = card.Subject;
             Question = card.Question;
             Answer = card.Answer;
-            IsCustom = card.IsCustom;    
+            IsCustom = card.IsCustom;
+            IsPrivate = card.IsPrivate;    
             DifficultyLevel = card.DifficultyLevel;   
             Notes = card.Notes;
             Tags = card.Tags;

--- a/src/Mentat.UI/Views/Card/AddEditCard.cshtml
+++ b/src/Mentat.UI/Views/Card/AddEditCard.cshtml
@@ -1,4 +1,8 @@
-﻿@using static Mentat.Domain.Constants
+﻿@using Microsoft.AspNetCore.Identity
+@using Mentat.UI.Areas.Identity.Data
+@using static Mentat.Domain.Constants
+
+@inject UserManager<MentatUser> UserManager
 
 @model Mentat.UI.ViewModels.CardViewModel
 
@@ -16,6 +20,12 @@
     <div class="col-md-4">
         <form asp-action="SaveCard" asp-route-id="@Model.Id">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div hidden class="form-group">
+                <label asp-for="Owner" class="control-label"></label>
+                <input asp-for="Owner" readonly class="form-control"
+                    value="@UserManager.GetUserName(User)"/>
+                <span asp-validation-for="Owner" class="text-danger"></span>
+            </div>
             <div class="form-group">
                 <label asp-for="Subject" class="control-label"></label>
                 <input asp-for="Subject" class="form-control" />

--- a/src/Mentat.UI/Views/Card/AddEditCard.cshtml
+++ b/src/Mentat.UI/Views/Card/AddEditCard.cshtml
@@ -41,11 +41,13 @@
                 <input asp-for="Answer" class="form-control" />
                 <span asp-validation-for="Answer" class="text-danger"></span>
             </div>
+            <!--
             <div class="form-group form-check">
                 <label class="form-check-label">
                     <input class="form-check-input" asp-for="IsCustom" /> @Html.DisplayNameFor(model => model.IsCustom)
                 </label>
             </div>
+            -->
             <div class="form-group form-check">
                 <label class="form-check-label">
                     <input class="form-check-input" asp-for="IsPrivate" /> @Html.DisplayNameFor(model => model.IsPrivate)

--- a/src/Mentat.UI/Views/Card/AddEditCard.cshtml
+++ b/src/Mentat.UI/Views/Card/AddEditCard.cshtml
@@ -46,6 +46,11 @@
                     <input class="form-check-input" asp-for="IsCustom" /> @Html.DisplayNameFor(model => model.IsCustom)
                 </label>
             </div>
+            <div class="form-group form-check">
+                <label class="form-check-label">
+                    <input class="form-check-input" asp-for="IsPrivate" /> @Html.DisplayNameFor(model => model.IsPrivate)
+                </label>
+            </div>
             <div class="form-group">
                 <label asp-for="DifficultyLevel" class="control-label"></label>
                 @Html.DropDownListFor(m => m.DifficultyLevel, ((DifficultyLevel[]) Enum.GetValues(typeof(DifficultyLevel))).ToList()

--- a/src/Mentat.UI/Views/Card/Delete.cshtml
+++ b/src/Mentat.UI/Views/Card/Delete.cshtml
@@ -35,6 +35,12 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.IsCustom)
         </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.IsPrivate)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.IsPrivate)
+        </dd>
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.DifficultyLevel)
         </dt>
@@ -46,6 +52,12 @@
         </dt>
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.Notes)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Owner)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Owner)
         </dd>
     </dl>
     

--- a/src/Mentat.UI/Views/Card/Details.cshtml
+++ b/src/Mentat.UI/Views/Card/Details.cshtml
@@ -28,14 +28,15 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.Answer)
         </dd>
-        
+
+        <!--
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.IsCustom)
         </dt>
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.IsCustom)
         </dd>
-        
+        -->
       
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.IsPrivate)

--- a/src/Mentat.UI/Views/Card/Details.cshtml
+++ b/src/Mentat.UI/Views/Card/Details.cshtml
@@ -28,12 +28,15 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.Answer)
         </dd>
+        
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.IsCustom)
         </dt>
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.IsCustom)
         </dd>
+        
+      
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.IsPrivate)
         </dt>

--- a/src/Mentat.UI/Views/Card/Details.cshtml
+++ b/src/Mentat.UI/Views/Card/Details.cshtml
@@ -35,6 +35,12 @@
             @Html.DisplayFor(model => model.IsCustom)
         </dd>
         <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.IsPrivate)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.IsPrivate)
+        </dd>
+        <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.DifficultyLevel)
         </dt>
         <dd class = "col-sm-10">

--- a/src/Mentat.UI/Views/Card/Details.cshtml
+++ b/src/Mentat.UI/Views/Card/Details.cshtml
@@ -46,6 +46,12 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.Notes)
         </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Owner)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Owner)
+        </dd>
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.Tags)
         </dt>

--- a/src/Mentat.UI/Views/Card/Index.cshtml
+++ b/src/Mentat.UI/Views/Card/Index.cshtml
@@ -1,4 +1,9 @@
-﻿@model Mentat.UI.ViewModels.CardViewModel
+﻿@using Microsoft.AspNetCore.Identity
+@using Mentat.UI.Areas.Identity.Data
+
+@inject UserManager<MentatUser> UserManager
+
+@model Mentat.UI.ViewModels.CardViewModel
 
 @{
     ViewData["Title"] = "Index";
@@ -69,7 +74,7 @@
             <td>
                 @Html.ActionLink("Edit", "AddEditCard", new {  id=card.Id }) |
                 @Html.ActionLink("Details", "Details", new { id=card.Id }) |
-                @Html.ActionLink("Delete", "Delete", new { id=card.Id })
+                @Html.ActionLink("Delete", "Delete", new { id=card.Id, user=UserManager.GetUserName(User) })
             </td>
         </tr>
 }

--- a/src/Mentat.UI/Views/Card/Index.cshtml
+++ b/src/Mentat.UI/Views/Card/Index.cshtml
@@ -13,6 +13,9 @@
     <thead>
         <tr>
             <th>
+                @Html.DisplayNameFor(model => model.Owner)
+            </th>
+            <th>
                 @Html.DisplayNameFor(model => model.Subject)
             </th>
             <th>
@@ -39,6 +42,9 @@
     <tbody>
 @foreach (var card in Model.Cards) {
         <tr>
+            <td>
+                @Html.DisplayFor(modelItem => card.Owner)
+            </td>
             <td>
                 @Html.DisplayFor(modelItem => card.Subject)
             </td>

--- a/src/Mentat.UI/Views/Card/Index.cshtml
+++ b/src/Mentat.UI/Views/Card/Index.cshtml
@@ -29,9 +29,11 @@
             <th>
                 @Html.DisplayNameFor(model => model.Answer)
             </th>
+            <!--
             <th>
                 @Html.DisplayNameFor(model => model.IsCustom)
             </th>
+            -->
             <th>
                 @Html.DisplayNameFor(model => model.IsPrivate)
             </th>
@@ -59,9 +61,11 @@
             <td>
                 @Html.DisplayFor(modelItem => card.Answer)
             </td>
+            <!--
             <td>
                 @Html.DisplayFor(modelItem => card.IsCustom)
             </td>
+            -->
             <td>
                 @Html.DisplayFor(modelItem => card.IsPrivate)
             </td>

--- a/src/Mentat.UI/Views/Card/Index.cshtml
+++ b/src/Mentat.UI/Views/Card/Index.cshtml
@@ -25,6 +25,9 @@
                 @Html.DisplayNameFor(model => model.IsCustom)
             </th>
             <th>
+                @Html.DisplayNameFor(model => model.IsPrivate)
+            </th>
+            <th>
                 @Html.DisplayNameFor(model => model.DifficultyLevel)
             </th>
             <th>
@@ -47,6 +50,9 @@
             </td>
             <td>
                 @Html.DisplayFor(modelItem => card.IsCustom)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => card.IsPrivate)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => card.DifficultyLevel)

--- a/src/Mentat.UI/Views/Student/Index.cshtml
+++ b/src/Mentat.UI/Views/Student/Index.cshtml
@@ -1,5 +1,9 @@
 ﻿@using Mentat.Domain.Models
 @using static Mentat.Domain.Constants
+@using Microsoft.AspNetCore.Identity
+@using Mentat.UI.Areas.Identity.Data
+
+@inject UserManager<MentatUser> UserManager
 
 @model StudentVM
 
@@ -178,7 +182,7 @@
                                     <text> | </text>
                                     <a href="javascript:;" title="Edit Flashcard"><i class="fa-solid fa-file-pen fsu-black-color" onclick="location.href='@Url.Action("AddEditCard", "Card", new { id = Model.AvailableCards[i - 1].CardID })';"></i></a>
                                     <text> | </text>
-                                    <a href="javascript:;" title="Delete Flashcard"><i class="fa-solid fa-trash-can fsu-maroon-color" data-id="@Model.AvailableCards[i - 1].CardID" data-togle="modal" data-target="#deleteModal"></i></a>
+                                    <a href="javascript:;" title="Delete Flashcard"><i class="fa-solid fa-trash-can fsu-maroon-color" onclick="location.href='@Url.Action("Delete", "Card", new { id = Model.AvailableCards[i - 1].CardID, user=UserManager.GetUserName(User) })';"></i></a>
                                 }
                             </td>
 						</tr>


### PR DESCRIPTION
This is a pull request to add M-03.05 Public/private flashcards to the development branch. This merge adds the functionality for a card to be set as public or private within mentat. When a card is created, an owner is set on that card and the user creating the card can choose if the card is public or private. Private cards can only be edited by the owner. Public cards can be edited by the owner, or if another user edits the card it creates a new card with the new user as the owner. Only the owner may delete a card. The IsPrivate attribute was added and the IsCustom attribute was hidden for users.